### PR TITLE
Sum of nth terrms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+setup(
+    name="Sum of the Nth terms",
+    description="Code Wars code-kata, sum of the nth terms",
+    version=0.1,
+    author="David Banks",
+    author_email="crashtack@gmail.com",
+    license='MIT',
+    py_modules=['sum_of_nth_terms'],
+    package_dir={'': 'src'},
+    install_requires=[],
+    extras_require={'test': ['pytest', 'pytest-watch', 'tox']},
+)

--- a/src/sum_of_nth_terms.py
+++ b/src/sum_of_nth_terms.py
@@ -1,0 +1,12 @@
+def series_sum(n):
+    # print('n = {}'.format(n))
+    out = 1
+    if n == 0:
+        return '0.00'
+    if n == 1:
+        return '1.00'
+    else:
+        for i in range(2, n + 1):
+            # print('range(n): {}'.format(i))
+            out += 1 / ((i * 2) + (i - 2))
+        return('{:.2f}'.format(out))

--- a/src/sum_of_nth_terms.py
+++ b/src/sum_of_nth_terms.py
@@ -1,4 +1,12 @@
 def series_sum(n):
+    ''' sum of the nth series:
+        Series: 1  1/4 + 1/7 + 1/10 + 1/13 + 1/16 +...
+        Examples:
+            series_sum(1) => 1 = "1"
+            series_sum(2) => 1 + 1/4 = "1.25"
+            series_sum(5) => 1 + 1/4 + 1/7 + 1/10 + 1/13 = "1.57"
+    '''
+
     # print('n = {}'.format(n))
     out = 1
     if n == 0:

--- a/src/sum_of_nth_terms.py
+++ b/src/sum_of_nth_terms.py
@@ -18,3 +18,16 @@ def series_sum(n):
             # print('range(n): {}'.format(i))
             out += 1 / ((i * 2) + (i - 2))
         return('{:.2f}'.format(out))
+
+
+def series_sum2(n):
+    return '{:.2f}'.format(sum(1.0 / (i * 3 + 1) for i in range(n)))
+
+
+def series_sum3(n):
+    amount = 0
+    for i in range(n):
+        amount += 1.0 / (i * 3 + 1)
+    return '{:.2f}'.format(amount)
+
+print(series_sum3(5))

--- a/src/test_sum_of_nth_terms.py
+++ b/src/test_sum_of_nth_terms.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+
+N_TABLE = [
+    (1, '1.00'),
+    (2, '1.25'),
+    (3, '1.39'),
+]
+
+
+@pytest.mark.parametrize('n, result', N_TABLE)
+def test_sum(n, result):
+    from sum_of_nth_terms import series_sum
+    assert series_sum(n) == result

--- a/src/test_sum_terms.py
+++ b/src/test_sum_terms.py
@@ -1,0 +1,3 @@
+Test.assert_equals(series_sum(1), "1.00")
+Test.assert_equals(series_sum(2), "1.25")
+Test.assert_equals(series_sum(3), "1.39")


### PR DESCRIPTION
It's a working solution

i handled the base cases of 1 and 0 with if-else statements. I saw some of the other solutions avoided this with better use of the range() method. I should have also used sum() instead of using an accumulator as in this one line example:

```
return '{:.2f}'.format(sum(1.0/(3 * i + 1) for i in range(n)))
```
